### PR TITLE
feat: spin up new WordPress instance with random ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,14 @@ WORDPRESS_DB_HOST=db
 WORDPRESS_DB_NAME=wordpress
 WORDPRESS_DB_USER=wordpress
 WORDPRESS_DB_PASSWORD=wordpress
+```
+
+## 🚀 Quick Start
+
+Spin up a fresh WordPress stack with random ports:
+
+```bash
+./new-wordpress.sh apple-silicon/docker-compose.yml
+```
+
+Each run creates a new project name so you always get a clean WordPress instance and it prints the ports for WordPress, MySQL, and phpMyAdmin.

--- a/apple-silicon/docker-compose.yml
+++ b/apple-silicon/docker-compose.yml
@@ -5,15 +5,15 @@ services:
     image: wordpress:latest
     restart: always
     ports:
-      - "8111:80"
+      - "0:80"
     environment:
       WORDPRESS_DB_HOST: ${WORDPRESS_DB_HOST}
       WORDPRESS_DB_NAME: ${WORDPRESS_DB_NAME}
       WORDPRESS_DB_USER: ${WORDPRESS_DB_USER}
       WORDPRESS_DB_PASSWORD: ${WORDPRESS_DB_PASSWORD}
     volumes:
-      - ./wordpress:/var/www/html
-      - ./php.ini:/usr/local/etc/php/conf.d/custom-php.ini 
+      - wp_data:/var/www/html
+      - ./php.ini:/usr/local/etc/php/conf.d/custom-php.ini
     networks:
       - wpnet
 
@@ -25,8 +25,10 @@ services:
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    ports:
+      - "0:3306"
     volumes:
-      - ./mysql:/var/lib/mysql
+      - db_data:/var/lib/mysql
     networks:
       - wpnet
 
@@ -34,7 +36,7 @@ services:
     image: phpmyadmin/phpmyadmin
     restart: always
     ports:
-      - "8112:80"
+      - "0:80"
     environment:
       PMA_HOST: ${WORDPRESS_DB_HOST}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
@@ -44,3 +46,7 @@ services:
 networks:
   wpnet:
     driver: bridge
+
+volumes:
+  db_data:
+  wp_data:

--- a/linux-arm64/docker-compose-x86.yml
+++ b/linux-arm64/docker-compose-x86.yml
@@ -5,14 +5,14 @@ services:
     image: wordpress:latest
     restart: always
     ports:
-      - "8080:80"
+      - "0:80"
     environment:
       WORDPRESS_DB_HOST: ${WORDPRESS_DB_HOST}
       WORDPRESS_DB_NAME: ${WORDPRESS_DB_NAME}
       WORDPRESS_DB_USER: ${WORDPRESS_DB_USER}
       WORDPRESS_DB_PASSWORD: ${WORDPRESS_DB_PASSWORD}
     volumes:
-      - ./wordpress:/var/www/html
+      - wp_data:/var/www/html
     networks:
       - wpnet
 
@@ -24,8 +24,10 @@ services:
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_USER: ${MYSQL_USER}
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    ports:
+      - "0:3306"
     volumes:
-      - ./mysql:/var/lib/mysql
+      - db_data:/var/lib/mysql
     networks:
       - wpnet
 
@@ -33,7 +35,7 @@ services:
     image: phpmyadmin/phpmyadmin
     restart: always
     ports:
-      - "8081:80"
+      - "0:80"
     environment:
       PMA_HOST: ${WORDPRESS_DB_HOST}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
@@ -43,3 +45,7 @@ services:
 networks:
   wpnet:
     driver: bridge
+
+volumes:
+  db_data:
+  wp_data:

--- a/new-wordpress.sh
+++ b/new-wordpress.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# Usage: ./new-wordpress.sh [path-to-compose-file]
+# Default compose file is apple-silicon/docker-compose.yml
+
+COMPOSE_FILE="${1:-apple-silicon/docker-compose.yml}"
+
+if [ ! -f "$COMPOSE_FILE" ]; then
+  echo "Compose file '$COMPOSE_FILE' not found" >&2
+  exit 1
+fi
+
+PROJECT="wp$(date +%s)"
+
+docker compose -f "$COMPOSE_FILE" -p "$PROJECT" up -d
+
+echo "Service ports:"
+printf "  - WordPress:  %s\n" "$(docker compose -f "$COMPOSE_FILE" -p "$PROJECT" port wordpress 80)"
+printf "  - MySQL:      %s\n" "$(docker compose -f "$COMPOSE_FILE" -p "$PROJECT" port db 3306)"
+printf "  - phpMyAdmin: %s\n" "$(docker compose -f "$COMPOSE_FILE" -p "$PROJECT" port phpmyadmin 80)"
+


### PR DESCRIPTION
## Summary
- use random host ports and named volumes in docker-compose files
- add helper script to launch a fresh WordPress stack and print service ports
- document quick start using the new script

## Testing
- `bash -n new-wordpress.sh`
- `docker compose -f apple-silicon/docker-compose.yml config` *(fails: command not found)*
- `docker compose -f linux-arm64/docker-compose-x86.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b8011153c483238b0d28528a80e30a